### PR TITLE
gitignore: add .DS_Store to gitignore file

### DIFF
--- a/recipe-app-code/.gitignore
+++ b/recipe-app-code/.gitignore
@@ -4,3 +4,4 @@
 node_modules
 dist
 .cache
+.DS_Store


### PR DESCRIPTION
DS_Store is a hidden folder added to MacOS folders that need to be added to the gitignore file.