### PR TITLE
Remove main.css and main.css.map from gitignore

### DIFF
--- a/recipe-app-code/.gitignore
+++ b/recipe-app-code/.gitignore
@@ -5,5 +5,3 @@ node_modules
 dist
 .cache
 .DS_Store
-main.css
-main.css.map


### PR DESCRIPTION
The pull request adding them to gitignore didn't specify the folder path to their location, so it didn't work.  But we need them for deployment, so we won't add them to gitignore.

This pull request just removes the filenames from gitignore.