### PR TITLE
Fix modal

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -21,6 +21,9 @@ const landingPage = document.querySelector("#landing-page");
 const searchResults = document.querySelector("#search-results-container");
 const modal = document.querySelector("dialog");
 
+// Global Variable to hold the recipes from the getData() function
+let recipes;
+
 // Constant needed for fetching from the TastyAPI
 const options = {
 	method: 'GET',

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -123,5 +123,5 @@ function createModal(e, recipes) {
             break;
         }
     }
-    dialog.showModal();
+    modal.showModal();
 }

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -56,8 +56,7 @@ async function getData() {
     // fetch recipes
     const res = await fetch(url, options);
     const data = await res.json();
-    let recipes = data.results;
-    return recipes;
+    recipes = data.results;
 };
 function showRecipes(recipes) {
     // remove previous search results

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -3,7 +3,7 @@ const searchForm = document.querySelector('form.search-form');
 const refreshButton = document.querySelector("#refresh-button");
 const modalCloseButton = document.querySelector(".recipe-details__exit-button");
 
-// DOM element to listen to and recieve data
+// DOM element to listen to and receive data
 const recipeList = document.querySelector("#search-results");
 
 // DOM elements to get user input from

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -86,7 +86,7 @@ function showRecipes(recipes) {
         searchResults.classList.remove("hidden");
     }
 };
-function createModal(e) {
+function createModal(e, recipes) {
     // get id of recipe card clicked
     let recipeID = e.target.id.slice(2);
     for (const index in recipes) {

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -43,7 +43,9 @@ refreshButton.addEventListener("click", () => {
     landingPage.classList.remove("hidden");
     searchResults.classList.add("hidden");
 })
-recipeList.addEventListener("click", createModal)
+recipeList.addEventListener("click", (e) => {
+    createModal(e, recipes);
+})
 modalCloseButton.addEventListener("click", () => {
     modal.close();
 });

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -36,7 +36,7 @@ const options = {
 // Event listeners
 searchForm.addEventListener('submit', async function (e) {
     e.preventDefault();
-    let recipes = await getData();
+    await getData();
     showRecipes(recipes);
 });
 refreshButton.addEventListener("click", () => {


### PR DESCRIPTION
I broke the modal.

Once we put the getData() function inside the searchForm eventListener, the modal didn't have access to the recipes data anymore because of scope.

The Problem: get recipe data that is created in the searchForm eventListener and pass it into the modal eventListener.

The Answer (part 1): a Global scope variable
https://raddevon.com/articles/share-variable-two-event-handlers-javascript/

The Answer (part 2): passing a parameter to an eventListener callback function by using an anonymous function
https://plainenglish.io/blog/passing-arguments-to-event-listeners-in-javascript-1a81bc397ecb

The steps:

- Declare a global variable to hold the recipes that are fetched from the API
   - `let recipes;` declare as a block level variable outside a block to make it global; use let because it will change
- Have getData() function set the global variable recipes instead of returning recipes
- searchForm eventListener
   - remove the local recipe variable declaration
   - just call getData(), it will set the global recipe variable
- modal eventListener
   - make callback an anonymous function `(e) => { createModal(e, recipes) }` instead of `createModal`
   - add recipes as a parameter to the createModal() function declaration
