### PR TITLE
Add space to regex

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -85,7 +85,7 @@ async function landingPageExamples() {
 landingPageExamples();
 
 function validateSearch(recipeInput) {
-    const unacceptedCharacters = /[^a-zA-Z]/;
+    const unacceptedCharacters = /[^a-zA-Z ]/;
     if (recipeInput.length === 0) {
        searchMessages.innerText = "You didn't input anything!";
     } else if (recipeInput.match(unacceptedCharacters)) {

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -10,7 +10,7 @@ const recipeList = document.querySelector("#search-results");
 // DOM elements to get user input from
 const searchBarInput = document.querySelector('#search-bar');
 
-// Modal element recieving data
+// Modal elements receiving data
 const modalImage = document.querySelector("#example1");
 const modalTitle = document.querySelector(".title-container h1");
 const modalCategory = document.querySelector(".meal-label h2")


### PR DESCRIPTION
Closes issue #108 

Add a space to the regex expression in the validateSearch() function so that ingredients with two or more words can still be accepted as valid ingredients, such as 'bell pepper' and 'brussel sprouts'.