### PR TITLE
Add recipeId to recipe-category in showRecipes() function

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -129,7 +129,7 @@ function showRecipes(recipes) {
         recipeObject.id = `roid${recipeID}`;
         recipeObject.innerHTML = `
             <img id="imid${recipeID}" class="recipe-image" src="${thumbnail}" alt="food picture">
-            <p class="recipe-category">${foundMealCategory}</p>
+            <p id="rcid${recipeID}" class="recipe-category">${foundMealCategory}</p>
             <div id="tcid${recipeID}" class="recipe-title__container">
                 <h2 id="rtid${recipeID}" class="recipe-title">${title}</h2>
             </div>


### PR DESCRIPTION
Clicking on the meal-category in a recipe card did not bring up the expected modal.

Fix: Add `id="rcid${recipeId}"` to the \<p> element created within the showRecipe() function.  This will give the createModal() function the id needed to find the correct recipe.