### PR TITLE
Javascript clean up

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -35,6 +35,9 @@ const options = {
 	}
 };
 
+// Call fetch right away for the landing page example recipes
+landingPageExamples();
+
 // Event listeners
 searchForm.addEventListener('submit', async function (e) {
     e.preventDefault();
@@ -88,7 +91,6 @@ async function landingPageExamples() {
     exampleRecipesDesc.classList.remove("hidden");
     showRecipes(recipes);
 };
-landingPageExamples();
 
 function validateSearch(recipeInput) {
     const unacceptedCharacters = /[^a-zA-Z ]/;

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -2,7 +2,6 @@
 const searchForm = document.querySelector('form.search-form');
 const refreshButton = document.querySelector("#refresh-button");
 const modalCloseButton = document.querySelector(".recipe-details__exit-button");
-const searchMessages = document.querySelector(".app-instructions");
 
 // DOM element to listen to and receive data
 const searchResults = document.querySelector("#search-results");
@@ -10,7 +9,8 @@ const searchResults = document.querySelector("#search-results");
 // DOM elements to get user input from
 const searchBarInput = document.querySelector('#search-bar');
 
-// Modal elements receiving data
+// Elements receiving data
+const searchMessages = document.querySelector(".app-instructions");
 const modalImage = document.querySelector("#example1");
 const modalTitle = document.querySelector(".title-container h1");
 const modalCategory = document.querySelector(".meal-label h2")


### PR DESCRIPTION
Move the landingPageExamples() function call up higher in main.js to make it a little bit quicker.

Move the searchMessages DOM reference down to the 'Elements receiving data' section in main.js


Oops:  I see that this pull request includes duplicate commits of my last two pull requests.  I'm too tired to redo them and I can't think of a reason it would matter.